### PR TITLE
fix installation error, missing not null statement for complex primar…

### DIFF
--- a/app/code/Esat/Esatisfaction/Setup/InstallSchema.php
+++ b/app/code/Esat/Esatisfaction/Setup/InstallSchema.php
@@ -18,6 +18,7 @@ class InstallSchema implements \Magento\Framework\Setup\InstallSchemaInterface
                 ], 'OrderItemId')
                 ->addColumn('order_id', \Magento\Framework\DB\Ddl\Table::TYPE_INTEGER, null, [
                     'primary' => true,
+                    'nullable' => false,
                 ], 'OrderId')
                 ->addColumn('item_id', \Magento\Framework\DB\Ddl\Table::TYPE_TEXT, 255, [
                     'nullable' => false,


### PR DESCRIPTION
Solves when installing the extension it gives an SQL error 

Syntax error or access violation: 1171 All parts of a PRIMARY KEY must be NOT NULL; if you need NULL in a key, use UNIQUE instead

